### PR TITLE
Use [bracketed tags] instead of +affixed tags

### DIFF
--- a/MichifVerbs.lexc
+++ b/MichifVerbs.lexc
@@ -2,19 +2,19 @@ Multichar_Symbols
 
 !! Below are the multichar symbols relevant to Michif verbal morphology
 
-+Obv  
-+Prs  
-+Fut  
-+Pst 
-+Incl
-+Excl
+[Obv]
+[Prs]
+[Fut]
+[Pst]
+[Incl]
+[Excl]
 
-+1SG
-+2SG
-+3SGA
-+NON3SG
-+1PL
-+3PLA
+[1SG]
+[2SG]
+[3SGA]
+[NON3SG]
+[1PL]
+[3PLA]
 
 !! Flags for Michif verbal morphology
 


### PR DESCRIPTION
We learned the hard way that bracketed tags, tends to confuse consumers of the FSTs a bit less than affixed tags.

---

It's not a big deal (Foma doesn't care which style is used), but we've found it makes mistakes easier to spot.